### PR TITLE
add Tooltip with pod name

### DIFF
--- a/client/PodDisplayManager.js
+++ b/client/PodDisplayManager.js
@@ -88,7 +88,7 @@ function PodDisplayManager($container){
 					}
 				}
 
-				$host.append('<div id="pod-' + j + '" class="' + classes.join(' ') + '">' + innerhtml + '</div>');
+				$host.append('<div id="pod-' + j + '" class="' + classes.join(' ') + '" + " title="Pod name: ' + slug + '">' + innerhtml + '</div>');
 				j++;
 			}
 


### PR DESCRIPTION
Added a tooltip that displays the pod name for each pod UI element (taken from the label 'name' shown when running the 'list pods' command in kubecfg)
