### PR TITLE
Not cutting the minion name when displaying it if it's an IPv4 address

### DIFF
--- a/client/PodDisplayManager.js
+++ b/client/PodDisplayManager.js
@@ -25,8 +25,12 @@ function PodDisplayManager($container){
 		// Get all of the different hosts
 		var hosts = {};
 		for (var p in pods) {
-			var host = (typeof pods[p].Host === 'string' ? pods[p].Host : '').split('.')[0];
-
+			var host = (typeof pods[p].Host === 'string' ? pods[p].Host : '');
+                        var temp = host.split('.');
+                        //checking if this is hostname or IPv4. If it's IP - no need to split it for display.
+                        if (temp.length != 4 || isNaN(temp[0]) || isNaN(temp[1]) || isNaN(temp[2]) || isNaN(temp[3])) {
+                                host = host.split('.')[0];
+                        }
 			if (host in hosts) {
 				hosts[host].push(pods[p]);
 			} else {


### PR DESCRIPTION
Sometimes a minion is represented by IP and not by hostname.
In that case, cutting it to till the first '.' appears as it is done today results with unclear and confusing displayed name (for example, 127.0.0.1 is displayed as 127). Hence, the patch adds logic to check whether the minion name is a hostname or an IP, and if it's an IP - display it 'as is'.
Note - IPv6 handling is NOT part of this patch.
